### PR TITLE
Autoload

### DIFF
--- a/spec/bin/store_spec.rb
+++ b/spec/bin/store_spec.rb
@@ -97,6 +97,21 @@ describe Bin::Store do
     it "works with symbol" do
       store.read(:foo).should == 'bar'
     end
+
+    it "works with not yet loaded classes" do
+      class Klass
+        def initialize(str)
+          @str = str
+        end
+        def say_hello
+          @str
+        end
+      end
+      obj = Klass.new("hello\n")
+      store.write('foo', obj)
+      dump = store.read('foo')
+      dump.say_hello.should == "hello\n"
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
figured out my issue, Marshal.load was complaining about classes not yet being loaded, so I added an autoload method. Had actually found reference to defunkt having to do something similar in a memcache plugin. Digging that you had watchr setup already in place, wish everyone used watchr.
