### PR TITLE
adding back rails 3.0.x compatibility

### DIFF
--- a/bin.gemspec
+++ b/bin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description  = 'ActiveSupport MongoDB Cache store.'
 
   s.add_dependency 'mongo',         '~> 1.3.0'
-  s.add_dependency 'activesupport', '~> 3.1.0'
+  s.add_dependency 'activesupport', '>= 3.0.0', '< 3.2.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Bundle installs fine, specs pass, works in app pegged to Rails 3.0.x.
